### PR TITLE
Fix errors in video downloaders and review scraper

### DIFF
--- a/api/reviews.py
+++ b/api/reviews.py
@@ -20,10 +20,10 @@ def scrapeReviews(ImdbId,sort="submissionDate",ratingFilter=10,dir="asc") :
     r = requests.get(headers={'User-Agent': 'Mozilla/5.0'},url=movie_url)
     # Create a BeautifulSoup object
     soup = BeautifulSoup(r.text, 'html.parser')
-    try :
-        reviews = soup.find_all('div',{'class' : 'imdb-user-review'})
-    except :
-        pass
+    try:
+        reviews = soup.find_all('div', {'class': 'imdb-user-review'})
+    except Exception:
+        reviews = []
         
     
     #review = soup.find('div',{'class' : 'imdb-user-review'})

--- a/downloaders/trailer_downloader/getTrailerByImdb.py
+++ b/downloaders/trailer_downloader/getTrailerByImdb.py
@@ -77,7 +77,7 @@ def download(video_url,video_id,imdbID) :
 def scrapeVidPage(video_id) :
     video_url= "https://www.imdb.com/video/"+video_id
     print(video_url)
-    r = requests.get(headers={'User-Agent': 'Mozilla/5.0'},url=video_url,headers={'User-Agent': 'Mozilla/5.0'})
+    r = requests.get(url=video_url, headers={'User-Agent': 'Mozilla/5.0'})
     soup = BeautifulSoup(r.text, 'html.parser')
     script =soup.find("script",{'type': 'application/json'})
     json_object = json.loads(script.string)

--- a/downloaders/videos_downloader/download_more_videos_movie_id.py
+++ b/downloaders/videos_downloader/download_more_videos_movie_id.py
@@ -95,7 +95,7 @@ def getmp4links(ImdbId,video_id) :
 #getmp4links(video_id="vi2922945817")
 
 def download(ImdbId,video_id,video_url) :
-    r = requests.get(headers={'User-Agent': 'Mozilla/5.0'},url=video_url, headers={'User-Agent': 'Mozilla/5.0'})
+    r = requests.get(url=video_url, headers={'User-Agent': 'Mozilla/5.0'})
     print("downloading  "+ video_id)
     os.makedirs("videos", exist_ok=True)
 

--- a/downloaders/videos_downloader/download_more_videos_recursively_by_movie_id.py
+++ b/downloaders/videos_downloader/download_more_videos_recursively_by_movie_id.py
@@ -70,8 +70,8 @@ def getmp4links(video_id,ImdbId) :
 
 #getmp4links(video_id="vi2922945817")
 
-def download(video_url,video_id,ImdbId) :
-    r = requests.get(headers={'User-Agent': 'Mozilla/5.0'},url=video_url, headers={'User-Agent': 'Mozilla/5.0'})
+def download(video_url, video_id, ImdbId):
+    r = requests.get(url=video_url, headers={'User-Agent': 'Mozilla/5.0'})
     unique_filename = str(uuid.uuid4())
     print("downloading  "+ unique_filename)
 


### PR DESCRIPTION
## Summary
- handle missing reviews gracefully
- fix duplicate headers in requests when downloading trailers and videos

## Testing
- `python -m py_compile api/api.py api/reviews.py api/scrapping_functions.py api/trendingMovies.py api/tvseries_scraper.py api/search_by_titles.py downloaders/*/*.py ImdbScraperV2/*/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6869de631ae8832fb96259d0333355c4